### PR TITLE
Fjern udgiver

### DIFF
--- a/bbr/bygningsanvendelse/v1.1.0.bygningsanvendelse.gc
+++ b/bbr/bygningsanvendelse/v1.1.0.bygningsanvendelse.gc
@@ -7,7 +7,6 @@
       <dcterms:language>da</dcterms:language>
       <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
       <dcterms:available>2024-12-05</dcterms:available>
-      <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
     </Description>
   </Annotation>
   <Identification>

--- a/bbr/bygningsanvendelse/v1.2.0.bygningsanvendelse.gc
+++ b/bbr/bygningsanvendelse/v1.2.0.bygningsanvendelse.gc
@@ -7,7 +7,6 @@
       <dcterms:language>da</dcterms:language>
       <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
       <dcterms:available>2024-12-06</dcterms:available>
-      <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
     </Description>
   </Annotation>
   <Identification>

--- a/matrikel/arealtype/v1.0.0.arealtype.gc
+++ b/matrikel/arealtype/v1.0.0.arealtype.gc
@@ -7,7 +7,6 @@
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-11</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/matrikel/forretningsproces/v1.0.0.forretningsproces.gc
+++ b/matrikel/forretningsproces/v1.0.0.forretningsproces.gc
@@ -7,7 +7,6 @@
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-11</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/matrikel/forretningsproces/v1.1.0.forretningsproces.gc
+++ b/matrikel/forretningsproces/v1.1.0.forretningsproces.gc
@@ -7,7 +7,6 @@
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-11</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/stednavne/aktualitetstype/v1.0.0.aktualitetstype.gc
+++ b/stednavne/aktualitetstype/v1.0.0.aktualitetstype.gc
@@ -7,7 +7,6 @@
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-05</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/stednavne/aktualitetstype/v1.1.0.aktualitetstype.gc
+++ b/stednavne/aktualitetstype/v1.1.0.aktualitetstype.gc
@@ -7,7 +7,6 @@
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-05</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/stednavne/bebyggelsestype/v1.0.0.bebyggelsestype.gc
+++ b/stednavne/bebyggelsestype/v1.0.0.bebyggelsestype.gc
@@ -9,7 +9,6 @@ Nascetur aptent neque lobortis senectus viverra. Posuere porttitor justo sem qua
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-05</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">

--- a/stednavne/bebyggelsestype/v1.1.0.bebyggelsestype.gc
+++ b/stednavne/bebyggelsestype/v1.1.0.bebyggelsestype.gc
@@ -8,7 +8,6 @@ Nascetur aptent neque lobortis senectus viverra. Posuere porttitor justo sem qua
          <dcterms:language>da</dcterms:language>
          <dcterms:license>https://creativecommons.org/licenses/by/4.0/deed.da</dcterms:license>
          <dcterms:available>2024-12-05</dcterms:available>
-         <dcterms:publisher>Klimadatastyrelsen</dcterms:publisher>
       </Description>
    </Annotation>
    <Identification xmlns:dcterms="http://purl.org/dc/terms/">


### PR DESCRIPTION
`dcterms:publisher` skal ikke længere være en del af det sæt af ekstra metadata-elementer.