### PR TITLE
Ignore LibreOffice lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Configuration file for Asciidoctor in IDEs
 .asciidoctorconfig.adoc
+# Eclipse project description file
 .project
+# LibreOffice locks
+.~lock.*#


### PR DESCRIPTION
Use same pattern as on
https://github.com/github/gitignore/blob/297239c101dcfdfae7e75757ed17ed993df0b4eb/Global/LibreOffice.gitignore#L1-L2

See more about lock files on
https://wiki.documentfoundation.org/Videos/Preventing_data_disaster#Lock_file

In addition, add comments regarding the other ignored files.