### PR TITLE
Tilføj attributter "description" og "keywords" til øverste README-fil

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,8 @@
 = Kodelisteregister
 :author: Klimadatastyrelsen
+:description: Denne side indeholder lister med koder, som indgår i nedenstående registre. Du kan finde kodelisterne og få adgang til dem i forskellige formater.
 :encoding: utf-8
+:keywords: kodeliste, kodelister, genericode
 :lang: da
 :nofooter:
 


### PR DESCRIPTION
genericode-transformer forventer at disse attributter er sat, se

* https://github.com/SDFIdk/genericode-transformer/blob/0eb28a65d75bfe917d927204c31ad6a6355ae40d/src/main/xml/xhtml/README-docinfo.html
* https://github.com/SDFIdk/genericode-transformer/blob/0eb28a65d75bfe917d927204c31ad6a6355ae40d/scripts/generate-code-list-register-site.bat#L52
* https://docs.asciidoctor.org/asciidoc/latest/docinfo/